### PR TITLE
Fixed: install() and uninstall() doesn't work with arguments

### DIFF
--- a/pyadb/adb.py
+++ b/pyadb/adb.py
@@ -458,8 +458,12 @@ class ADB():
         self.__clean__()
         if package is None:
             return self.__output
-        cmd = ['uninstall',"%s" % (package if keepdata is True else "-k %s" % package )]
-        self.run_cmd(cmd)
+
+        cmd = 'uninstall '
+        if keepdata:
+            cmd += '-k '
+        cmd += package
+        self.run_cmd(cmd.split())
         return self.__output
 
     def install(self,fwdlock=False,reinstall=False,sdcard=False,pkgapp=None):
@@ -482,8 +486,9 @@ class ADB():
             cmd += "-r "
         if sdcard is True:
             cmd += "-s "
-        
-        self.run_cmd([cmd,pkgapp])
+ 
+        cmd += pkgapp
+        self.run_cmd(cmd.split())
         return self.__output
 
     def find_binary(self,name=None):


### PR DESCRIPTION
the argument of self.run_cmd() must be either a single string containing
all the cmd arguments or a sequence of cmd arguments. In install() and
uninstall(), arguments might be sent as something like:
['install -l -r', pkgapp] or ['uninstall', '-k ' + package]

These kind of arguemnts will fail to run.
(tested on python2.7/Ubuntu14.04)