### PR TITLE
Allow 'devices' command to run without specifying a target device

### DIFF
--- a/pyadb/adb.py
+++ b/pyadb/adb.py
@@ -54,7 +54,7 @@ class ADB():
     def __build_command__(self,cmd):
         ret = None
 
-        if self.__devices is not None and len(self.__devices) > 1 and self.__target is None:
+        if self.__devices is not None and len(self.__devices) > 1 and self.__target is None and "devices" not in cmd:
             self.__error = "Must set target device first"
             self.__return = 1
             return ret


### PR DESCRIPTION
Hi there, I added an extra condition to the  __build_command__ method to solve a problem that occurs when a second device is attached after running with a single device for a while. Without the change, there seems to be a device connectivity state sync issue where commands can't be issued following the addition of a new device. So, I added an exception for the "devices" ADB command since it can be safely run without specifying a target device, which also allows device connectivity state to be restored. 