### PR TITLE
Fix usb mode

### DIFF
--- a/pyadb/adb.py
+++ b/pyadb/adb.py
@@ -54,7 +54,7 @@ class ADB():
     def __build_command__(self,cmd):
         ret = None
 
-        if self.__devices is not None and len(self.__devices) > 1 and self.__target is None:
+        if self.__devices is not None and len(self.__devices) > 1 and self.__target is None and "devices" not in cmd:
             self.__error = "Must set target device first"
             self.__return = 1
             return ret

--- a/pyadb/adb.py
+++ b/pyadb/adb.py
@@ -237,7 +237,7 @@ class ADB():
             if mode == 'serial':
                 self.__devices = self.__output.partition('\n')[2].replace('device','').split()
             elif mode == 'usb':
-                self.__devices = re.sub('.+usb:|\sproduct.+|\n\n', '', self.__output.partition('\n')[2]).split()
+                self.__devices = re.sub('.+device |\sproduct.+|\n\n', '', self.__output.partition('\n')[2]).split()
             
             if self.__devices[1:] == ['no','permissions']:
                 error = 2


### PR DESCRIPTION
Fix for #11 

Patch causes the sub-string "usb:" to remain in the extracted USB identifier for each device. This change fixes the following misbehavior:

0. Call get_devices(mode="usb") to populate ADB.__devices (with truncated USB Bus IDs). 
1. Calls to set_target_device(<truncated USB Bus ID>) will falsely succeed. 
2. Subsequent calls to adb, e.g. shell_command(), will fail because when the 'adb -s' option is passed a USB identifier, it expects the full identifier string.  